### PR TITLE
fixes for the read method in java

### DIFF
--- a/RESOLVE/Main/Concepts/Standard/Boolean_Template/Std_Boolean_Realiz.java
+++ b/RESOLVE/Main/Concepts/Standard/Boolean_Template/Std_Boolean_Realiz.java
@@ -135,6 +135,7 @@ public class Std_Boolean_Realiz extends RESOLVE_BASE implements Boolean_Template
 
   public void Read(Boolean_Template.Boolean b) {
 	((Std_Boolean_Realiz.Boolean)b).val = TextIO.getBoolean();
+	TextIO.getln();
   } 
 
   public void Write(Boolean_Template.Boolean b) {

--- a/RESOLVE/Main/Concepts/Standard/Character_Template/Std_Character_Realiz.java
+++ b/RESOLVE/Main/Concepts/Standard/Character_Template/Std_Character_Realiz.java
@@ -139,6 +139,7 @@ public class Std_Character_Realiz extends RESOLVE_BASE implements Character_Temp
 
   public void Read(Character_Template.Character c) {
 	((Std_Character_Realiz.Character)c).val = TextIO.getChar();
+	TextIO.getln();
   } 
 
   public void Write(Character_Template.Character c) {

--- a/RESOLVE/Main/Concepts/Standard/Integer_Template/Std_Integer_Realiz.java
+++ b/RESOLVE/Main/Concepts/Standard/Integer_Template/Std_Integer_Realiz.java
@@ -179,6 +179,7 @@ public class Std_Integer_Realiz extends RESOLVE_BASE implements Integer_Template
 
   public void Read(Integer_Template.Integer i) {
 	((Std_Integer_Realiz.Integer)i).val = TextIO.getInt();
+	TextIO.getln();
   } 
 
   public void Write(Integer_Template.Integer i) {


### PR DESCRIPTION
RESOLVE Boolean, Integer and Character's java code all use the TextIO class. Problem is that when you hit enter and introduce either "CRLF" or "LF" (OS dependent), that gets consumed as the next input, causing an input read statement to incorrectly execute.

Pivotal Story: Read Operation Bug for Standard Types
Pivotal Story Number: #60513298
