### PR TITLE
syntax changes to type and type family declarations

### DIFF
--- a/RESOLVE/Main/Concepts/Basic_Map_Template/Basic_Map_Template.co
+++ b/RESOLVE/Main/Concepts/Basic_Map_Template/Basic_Map_Template.co
@@ -9,10 +9,9 @@ Concept Basic_Map_Template (Type Key; Type Info; evaluates Max_Size: Integer;
 
 	Type Family Map is modeled by (Key -> Info); 
 		exemplar M;
-
 		constraint Dev_Ct (M) <= Max_Size;
-
         initialization ensures Dev_Ct (M) = 0;
+	end;
 
 	Oper Define (restores k: Key; alters I: Info; updates M: Map);
 		requires	Dev_Ct (M) < Max_Size and 

--- a/RESOLVE/Main/Concepts/Communally_Bounded_List_Template/Communally_Bounded_List_Template.co
+++ b/RESOLVE/Main/Concepts/Communally_Bounded_List_Template/Communally_Bounded_List_Template.co
@@ -9,7 +9,7 @@ Concept Communally_Bounded_List_Template( type Entry; eval Initial_Capacity: Int
 	Facility_Initialization
 		ensures Remaining_Cap = Initial_Capacity;
 
-	Family List is modeled by Cart_Prod
+	Type Family List is modeled by Cart_Prod
 			Prec, Rem: Str(Entry);
 		end;
 		exemplar P;
@@ -18,6 +18,7 @@ Concept Communally_Bounded_List_Template( type Entry; eval Initial_Capacity: Int
 		finalization
 			updates Remaining_Cap;
 			ensures Remaining_Cap = #Remaining_Cap + |P.Prec o P.Rem|;
+	end;
 
 	Oper Advance( upd P: List );
 		requires P.Rem /= Empty_String;

--- a/RESOLVE/Main/Concepts/Globally_Bounded_List_Template/Globally_Bounded_List_Template.co
+++ b/RESOLVE/Main/Concepts/Globally_Bounded_List_Template/Globally_Bounded_List_Template.co
@@ -2,11 +2,12 @@ Concept Globally_Bounded_List_Template( type Entry);
 					uses String_Theory;
 
 		Type Family List is modeled by Cart_Prod
-			Prec, Rem: Str(Entry);
-		end;
+				Prec, Rem: Str(Entry);
+			end;
 			exemplar P;
 			initialization
 				ensures P.Prec = Empty_String and P.Rem = Empty_String;
+		end;
 
 		Oper Advance( upd P: List );
 			requires not(P.Rem = Empty_String);

--- a/RESOLVE/Main/Concepts/Globally_Bounded_List_Template/Std_Unbounded_List_Realiz.rb
+++ b/RESOLVE/Main/Concepts/Globally_Bounded_List_Template/Std_Unbounded_List_Realiz.rb
@@ -3,9 +3,10 @@ Realization Stack_Based_Realiz for Globally_Bounded_List_Template;
     Facility SF is Globally_Bounded_Stack_Template(Entry)
             realized by Array_Realiz;
 
-    	Type List = Record
-		Left: SF.Stack;
-		Right: SF.Stack;
+    Type List is represented by Record
+			Left: SF.Stack;
+			Right: SF.Stack;
+		end;
 	end;
 
 	Procedure Advance( upd P: List );
@@ -52,13 +53,16 @@ Realization Stack_Based_Realiz for Globally_Bounded_List_Template;
 
 	end;
 	
+	Procedure Is_Prec_Empty( rest P: List ): Boolean;
 	
-		Procedure Is_Prec_Empty( rest P: List ): Boolean;
-		end;		
-		Procedure Is_Rem_Empty( rest P: List ): Boolean;
-		end;
+	end;		
+	
+	Procedure Is_Rem_Empty( rest P: List ): Boolean;
+	
+	end;
 
-		Procedure Clear( clr P: List );
-		end;
+	Procedure Clear( clr P: List );
+	
+	end;
 
 end Stack_Based_Realiz;

--- a/RESOLVE/Main/Concepts/Globally_Bounded_Queue_Template/Globally_Bounded_Queue_Template.co
+++ b/RESOLVE/Main/Concepts/Globally_Bounded_Queue_Template/Globally_Bounded_Queue_Template.co
@@ -5,6 +5,7 @@ Concept Globally_Bounded_Queue_Template(type Entry);
 	Type Family Queue is modeled by Str(Entry);
 		exemplar Q;
 		initialization ensures Q = Empty_String;
+	end;
  
 	Operation Enqueue(alters E: Entry; updates Q: Queue);
 		ensures Q = #Q o <#E>;

--- a/RESOLVE/Main/Concepts/Globally_Bounded_Queue_Template/Queue_Location_Linking_Realiz.rb
+++ b/RESOLVE/Main/Concepts/Globally_Bounded_Queue_Template/Queue_Location_Linking_Realiz.rb
@@ -10,47 +10,49 @@ Realization Queue_Location_Linking_Realiz for Globally_Bounded_Queue_Template;
 			contentsContext : Z -> Entry): Str(Entry) = 
 		{{Empty_String if first = Void;
 		  <contentsContext(first)> o 
-		  	Str_Info(refContext(first), refContext, 			contentsContext) otherwise;}};
+		  	Str_Info(refContext(first), refContext, contentsContext) otherwise;}};
 
     Facility Entry_Ptr_Fac is Location_Linking_Template_1(Entry) 
         realized by Std_Location_Linking_Realiz;
 
     Type Queue is represented by Record
-		Front: Entry_Ptr_Fac.Position;
-		Back: Entry_Ptr_Fac.Position;
-	end;
-
-    convention Is_Reachable(Q.Front, Q.Back, Ref) and 
+			Front: Entry_Ptr_Fac.Position;
+			Back: Entry_Ptr_Fac.Position;
+		end;
+		convention Is_Reachable(Q.Front, Q.Back, Ref) and 
 			(Ref(Q.Back) = Void) and
 			(Q.Back = Void iff Q.Front = Void);
-    correspondence Conc.Q = Str_Info(Q.Front, Content, Ref);
+		correspondence Conc.Q = Str_Info(Q.Front, Content, Ref);
+	end;
 	
     Procedure Dequeue(replaces R: Entry; updates Q: Queue);
-	Var Temp: Position;
-
-	Swap_Info(Q.Front, R);
-	Follow_Link(Q.Front);
-	If (Is_At_Void(Q.Front)) then
-		Reset_To_Void(Q.Back);
-	end;
+		Var Temp: Position;
+		
+		Swap_Info(Q.Front, R);
+		Follow_Link(Q.Front);
+		
+		If (Is_At_Void(Q.Front)) then
+			Reset_To_Void(Q.Back);
+		end;
     end Dequeue;
 
     Procedure Enqueue(alters E: Entry; updates Q: Queue);
-	Var Temp: Position;
+		Var Temp: Position;
 
-	Take_New_Location(Temp);
-	Swap_Info(Temp, E);
-	Redirect_Link(Q.Back, Temp);
-	If (Is_At_Void(Q.Front)) then
-		Relocate_to(Q.Back, Q.Front);
-	end;
+		Take_New_Location(Temp);
+		Swap_Info(Temp, E);
+		Redirect_Link(Q.Back, Temp);
+		
+		If (Is_At_Void(Q.Front)) then
+			Relocate_to(Q.Back, Q.Front);
+		end;
     end Enqueue;
 
     Procedure Is_Empty(restores Q: Queue) : Boolean;
-	Var Temp: Position;
-
-	Is_Empty := Is_At_Void(Q.Front);
-    end Is_Empty;
+		Var Temp: Position;
+		
+		Is_Empty := Is_At_Void(Q.Front);
+	end Is_Empty;
 
     Procedure Clear(clears Q: Queue);
         Reset_To_Void(Q.Front);

--- a/RESOLVE/Main/Concepts/Globally_Bounded_Stack_Template/Globally_Bounded_Stack_Template.co
+++ b/RESOLVE/Main/Concepts/Globally_Bounded_Stack_Template/Globally_Bounded_Stack_Template.co
@@ -5,6 +5,7 @@ Concept Globally_Bounded_Stack_Template(type Entry);
 	Type Family Stack is modeled by Str(Entry);
 		exemplar S;
 		initialization ensures S = Empty_String;
+	end;
 
 	Operation Push(alters E: Entry; updates S: Stack); 
 		ensures S = <#E> o #S;

--- a/RESOLVE/Main/Concepts/Globally_Bounded_Stack_Template/Location_Linking_Realiz.rb
+++ b/RESOLVE/Main/Concepts/Globally_Bounded_Stack_Template/Location_Linking_Realiz.rb
@@ -13,36 +13,36 @@ Realization Location_Linking_Realiz for Globally_Bounded_Stack_Template;
 			contentsContext : Z -> Entry): Str(Entry) = 
 		{{Empty_String if first = Void;
 		  <contentsContext(first)> o 
-		  	Str_Info(refContext(first), refContext, 			contentsContext) otherwise;}};
+		  	Str_Info(refContext(first), refContext, contentsContext) otherwise;}};
 
     Facility Entry_Ptr_Fac is Location_Linking_Template_1(Entry) 
         realized by Std_Location_Linking_Realiz;
 
     Type Stack is represented by Entry_Ptr_Fac.Position;
-
-    convention Is_Void_Reachable(S, Ref);
-    correspondence Conc.S = Str_Info(S, Content, Ref);
+		convention Is_Void_Reachable(S, Ref);
+		correspondence Conc.S = Str_Info(S, Content, Ref);
+	end;
 	
     Procedure Pop(replaces R: Entry; updates S: Stack);
-	Var Temp: Position;
+		Var Temp: Position;
 
-	Swap_Info(S, R);
-	Follow_Link(S);
+		Swap_Info(S, R);
+		Follow_Link(S);
     end Pop;
 
     Procedure Push(alters E: Entry; updates S: Stack); 
-	Var Temp: Position;
+		Var Temp: Position;
 
-	Take_New_Location(Temp);
-	Swap_Info(Temp, E);
-	Redirect_Link(Temp, S);
-	Relocate_to(Temp, S);
+		Take_New_Location(Temp);
+		Swap_Info(Temp, E);
+		Redirect_Link(Temp, S);
+		Relocate_to(Temp, S);
     end Push;
 
     Procedure Is_Empty(restores S : Stack) : Boolean;
-	Var Temp: Position;
+		Var Temp: Position;
 
-	Is_Empty := Is_At_Void(S);
+		Is_Empty := Is_At_Void(S);
     end Is_Empty;
 
     Procedure Clear(clears S: Stack);

--- a/RESOLVE/Main/Concepts/Globally_Bounded_Stack_Template/Skeleton_Realiz.rb
+++ b/RESOLVE/Main/Concepts/Globally_Bounded_Stack_Template/Skeleton_Realiz.rb
@@ -2,7 +2,8 @@ Realization Skeleton_Realiz for Globally_Bounded_Stack_Template;
     uses Location_Linking_Template_1;
 
     Type Stack = Integer;
-    correspondence Conc.S = Empty_String;
+		correspondence Conc.S = Empty_String;
+	end;
 
     Procedure Pop(replaces R: Entry; updates S: Stack);
 

--- a/RESOLVE/Main/Concepts/Map_Template/Map_Template.co
+++ b/RESOLVE/Main/Concepts/Map_Template/Map_Template.co
@@ -12,6 +12,7 @@ Concept Map_Template (Type Key; Type Info; evaluates Max_Size: Integer);
 		initialization
 			ensures
 				M.KeySet = empty_set;
+	end;
 
 	Operation Put(restores k : Key; alters I : Info; updates M : Map);
 		requires	||M.KeySet|| < Max_Size and

--- a/RESOLVE/Main/Concepts/Preemptable_Queue_Template/Preemptable_Queue_Template.co.txt
+++ b/RESOLVE/Main/Concepts/Preemptable_Queue_Template/Preemptable_Queue_Template.co.txt
@@ -3,9 +3,10 @@ Concept Preemptable_Queue_Template(type Entry; evaluates Max_Length: Integer);
     requires Max_Length > 0;
  
     Type Family P_Queue is modeled by Str(Entry);
-    exemplar Q;
-    constraint |Q| <= Max_Length;
-    initialization ensures Q = Empty_String;
+		exemplar Q;
+		constraint |Q| <= Max_Length;
+		initialization ensures Q = Empty_String;
+	end;
  
     Operation Enqueue(alters E: Entry; reassigns Q: P_Queue);
         requires |Q| < Max_Length;
@@ -22,9 +23,7 @@ Concept Preemptable_Queue_Template(type Entry; evaluates Max_Length: Integer);
     Operation Swap_Last_Entry(updates E: Entry; updates Q: P_Queue);
         requires |Q| /= 0;
         ensures Q = Prt_Btwn(0, |#Q| - 1, #Q) o <#E> and
-                E = DeString(Prt_Btwn(|#Q| - 1, |#Q|, #Q)); 
-		
-		
+                E = DeString(Prt_Btwn(|#Q| - 1, |#Q|, #Q));
 
     Operation Length(restores Q: P_Queue): Integer;
         ensures Length = (|Q|);

--- a/RESOLVE/Main/Concepts/Prioritizer_Template/Prioritizer_Template.co
+++ b/RESOLVE/Main/Concepts/Prioritizer_Template/Prioritizer_Template.co
@@ -14,6 +14,7 @@ Concept Prioritizer_Template( type Entry; evaluates Max_Capacity: Integer; defin
         exemplar P;
         constraint Total_Entry_Ct(P) <= Max_Capacity;
         initialization ensures Total_Entry_Ct(P) = 0 and P.Accepting;
+	end;
 
     --------------------------------------------------------------
 

--- a/RESOLVE/Main/Concepts/Queue_Template/Circular_Array_Realiz.rb
+++ b/RESOLVE/Main/Concepts/Queue_Template/Circular_Array_Realiz.rb
@@ -52,6 +52,7 @@ Realization Circular_Array_Realiz for Queue_Template;
             Conc.Q = (Concatenation i: Z
             where Q.Front <= i <= Q.Front + Q.Length - 1,
             {<Q.Contents(i mod Max_Length)>});
+	end;
        
     Procedure Enqueue(alters E: Entry; updates Q: Queue);
         Q.Contents[(Q.Front + Q.Length) mod Max_Length] :=: E;

--- a/RESOLVE/Main/Concepts/Queue_Template/Queue_Template.co
+++ b/RESOLVE/Main/Concepts/Queue_Template/Queue_Template.co
@@ -3,9 +3,10 @@ Concept Queue_Template(type Entry; evaluates Max_Length: Integer);
     requires Max_Length > 0;
  
     Type Family Queue is modeled by Str(Entry);
-    exemplar Q;
-    constraint |Q| <= Max_Length;
-    initialization ensures Q = Empty_String;
+		exemplar Q;
+		constraint |Q| <= Max_Length;
+		initialization ensures Q = Empty_String;
+	end;
  
     Operation Enqueue(alters E: Entry; updates Q: Queue);
         requires |Q| < Max_Length;

--- a/RESOLVE/Main/Concepts/Search_Store_Template/Search_Store_Template.co
+++ b/RESOLVE/Main/Concepts/Search_Store_Template/Search_Store_Template.co
@@ -7,6 +7,7 @@ Concept Search_Store_Template (Type Key; evaluates Max_Capacity: Integer);
     	exemplar S;
 		constraint ||S|| <= Max_Capacity;
             initialization ensures S = {};
+	end;
 
 	Oper Add (restores k: Key; updates S: Store);
 		requires ||S|| < Max_Capacity and k is_not_in S;

--- a/RESOLVE/Main/Concepts/Stack_Template/Array_Realiz.rb
+++ b/RESOLVE/Main/Concepts/Stack_Template/Array_Realiz.rb
@@ -51,6 +51,7 @@ Realization Array_Realiz for Stack_Template;
         correspondence
             Conc.S = Reverse(Concatenate(S.Contents, 
 		S.Top));
+	end;
 
     Procedure Push(alters E: Entry; updates S: Stack);
         S.Top := S.Top + 1;

--- a/RESOLVE/Main/Concepts/Stack_Template/Clean_Array_Realiz.rb
+++ b/RESOLVE/Main/Concepts/Stack_Template/Clean_Array_Realiz.rb
@@ -15,6 +15,7 @@ Realization Clean_Array_Realiz for Stack_Template;
         correspondence
             Conc.S = Reverse(Concatenation i: Z
             where 1 <= i <= S.Top, <S.Contents(i)>);
+	end;
 
     Procedure Push(alters E: Entry; updates S: Stack);
         S.Top := S.Top + 1;

--- a/RESOLVE/Main/Concepts/Stack_Template/Init_Array_Realiz.rb
+++ b/RESOLVE/Main/Concepts/Stack_Template/Init_Array_Realiz.rb
@@ -14,6 +14,8 @@ Realization Init_Array_Realiz for Stack_Template;
         initialization
            S.Top := 1;
         end;
+	end;
+	
     Procedure Push(alters E: Entry; updates S: Stack);
         E :=: S.Contents[S.Top];
         S.Top := S.Top + 1;

--- a/RESOLVE/Main/Concepts/Stack_Template/Stack_Template.co
+++ b/RESOLVE/Main/Concepts/Stack_Template/Stack_Template.co
@@ -6,6 +6,7 @@ Concept Stack_Template(type Entry; evaluates Max_Depth: Integer);
         exemplar S;
         constraint |S| <= Max_Depth;
         initialization ensures S = Empty_String;
+	end;
 
     Operation Push(alters E: Entry; updates S: Stack); 
         requires |S| < Max_Depth;

--- a/RESOLVE/Main/Concepts/Standard/Boolean_Template/Boolean_Template.co
+++ b/RESOLVE/Main/Concepts/Standard/Boolean_Template/Boolean_Template.co
@@ -44,6 +44,7 @@ Concept Boolean_Template;
     Type Family Boolean is modeled by B;
         exemplar b;
         initialization ensures b = true;
+	end;
 
     Operation True(): Boolean;
         ensures True = (true);

--- a/RESOLVE/Main/Concepts/Standard/Char_Str_Template/Char_Str_Template.co
+++ b/RESOLVE/Main/Concepts/Standard/Char_Str_Template/Char_Str_Template.co
@@ -47,6 +47,7 @@ Concept Char_Str_Template;
         constraints |s| <= Max_Char_Str_Len;
         initialization 
 		ensures s = Empty_String;
+	end;
 
     (*Operation Char_Str_for(evaluates c: Character): Char_Str;
         ensures Char_Str_for = ( <c> );*)

--- a/RESOLVE/Main/Concepts/Standard/Character_Template/Character_Template.co
+++ b/RESOLVE/Main/Concepts/Standard/Character_Template/Character_Template.co
@@ -48,6 +48,7 @@ Concept Character_Template;
 		constraints c < Last_Char_Num;
 		initialization 
 			ensures c = 0;
+	end;
 
     Operation Char_to_Int(evaluates c: Character): Integer;
         ensures Char_to_Int = ( c );

--- a/RESOLVE/Main/Concepts/Standard/Integer_Template/Integer_Template.co
+++ b/RESOLVE/Main/Concepts/Standard/Integer_Template/Integer_Template.co
@@ -50,6 +50,7 @@ Concept Integer_Template;
         exemplar i;
         constraint min_int <= i <= max_int;
         initialization ensures i = 0;
+	end;
 
     Operation Is_Zero(evaluates i: Integer): Boolean;
         ensures	Is_Zero = ( i = 0 );

--- a/RESOLVE/Main/Concepts/Standard/Location_Linking_Template_1/Location_Linking_Template_1.co
+++ b/RESOLVE/Main/Concepts/Standard/Location_Linking_Template_1/Location_Linking_Template_1.co
@@ -11,6 +11,7 @@ Concept Location_Linking_Template_1(type Info);
 	Type Family Position is modeled by Z;
 		exemplar P;
 		initialization ensures P = Void;
+	end;
 
 	Operation Take_New_Location(updates P: Position);
 		ensures P /= Void;

--- a/RESOLVE/Main/Concepts/Standard/Static_Array_Template/Static_Array_Template.co
+++ b/RESOLVE/Main/Concepts/Standard/Static_Array_Template/Static_Array_Template.co
@@ -7,6 +7,7 @@ Concept Static_Array_Template(type Entry; evaluates Lower_Bound, Upper_Bound: In
 		constraint true;
 			initialization ensures 
 			for all i: Z, Entry.Is_Initial(A(i));
+	end;
 
     Operation Swap_Entry(updates A: Static_Array; updates E: Entry; evaluates i: Integer); 
         requires Lower_Bound <= i  and i <= Upper_Bound;

--- a/RESOLVE/Main/Concepts/Standard/io/Seq_Input_Template.co
+++ b/RESOLVE/Main/Concepts/Standard/io/Seq_Input_Template.co
@@ -1,11 +1,13 @@
 Concept Seq_Input_Template;
 
-   Type Family Seq_Input is modeled by B;
-      exemplar f;
-
-   Operation Open_Read_File(evaluates f: Char_Str): Seq_Input;
-   Operation Read_Line_From_File(evaluates br: Seq_Input): Char_Str;
-   Operation Close_Read_File(evaluates br: Seq_Input);
-
+	Type Family Seq_Input is modeled by B;
+		exemplar f;
+	end;
+	
+	Operation Open_Read_File(evaluates f: Char_Str): Seq_Input;
+	
+	Operation Read_Line_From_File(evaluates br: Seq_Input): Char_Str;
+	
+	Operation Close_Read_File(evaluates br: Seq_Input);
 
 end Seq_Input_Template;

--- a/RESOLVE/Main/Concepts/Standard/io/Seq_Output_Template.co
+++ b/RESOLVE/Main/Concepts/Standard/io/Seq_Output_Template.co
@@ -1,11 +1,13 @@
 Concept Seq_Output_Template;
 
-   Type Family Seq_Output is modeled by B;
-      exemplar f;
+	Type Family Seq_Output is modeled by B;
+		exemplar f;
+	end;
+	
+	Operation Open_Write_File(evaluates f: Char_Str): Seq_Output;
 
-   Operation Open_Write_File(evaluates f: Char_Str): Seq_Output;
-   Operation Write_To_File(evaluates pw: Seq_Output;updates s: Char_Str);
-   Operation Close_Write_File(evaluates pw: Seq_Output);
+	Operation Write_To_File(evaluates pw: Seq_Output;updates s: Char_Str);
 
+	Operation Close_Write_File(evaluates pw: Seq_Output);
 
 end Seq_Output_Template;

--- a/RESOLVE/Main/Concepts/Text_Template/Queue_Based_Realiz.rb
+++ b/RESOLVE/Main/Concepts/Text_Template/Queue_Based_Realiz.rb
@@ -6,9 +6,10 @@ Realization Queue_Based_Realiz for Text_Template;
         realized by Circular_Array_Realiz;
 
     Type Text = Record
-        Contents: QF. Queue;
-    end;
-    correspondence Conc.S = S.Contents;
+			Contents: QF. Queue;
+		end;
+		correspondence Conc.S = S.Contents;
+	end;
  
     Procedure Add(restores C: Character; updates S: Text);
         Var Temp: Character;

--- a/RESOLVE/Main/Concepts/Text_Template/Text_Template.co
+++ b/RESOLVE/Main/Concepts/Text_Template/Text_Template.co
@@ -6,10 +6,11 @@ Concept Text_Template;
 --    Defines Max_Size: N;
 --    constraints Max_Size > 0;
 
-    Type Family Text is modeled by Str(N);
-    exemplar S;
---    constraint |S| <= Max_Size;
-    initialization ensures S = Empty_String;
+	Type Family Text is modeled by Str(N);
+		exemplar S;
+		--constraint |S| <= Max_Size;
+		initialization ensures S = Empty_String;
+	end;
  
     Operation Add(restores C: Character; updates S: Text);
 --        requires |S| < Max_Size;


### PR DESCRIPTION
All the type and type family declarations should end with "end;"

Note: Record and Cart_Prod both end with "end;", so in cases where there isn't anything following that, it should be "end; end;" to note end of Record/Cart_Prod and end of type declaration.
