### PR TITLE
Minor Update to Remove_Last_Capability

### DIFF
--- a/RESOLVE/Main/Concepts/Queue_Template/Remove_Last_Capability.en
+++ b/RESOLVE/Main/Concepts/Queue_Template/Remove_Last_Capability.en
@@ -1,6 +1,6 @@
 Enhancement Remove_Last_Capability for Queue_Template;
     Operation Remove_Last(updates Q: Queue; replaces E: Entry);
-        requires |Q| /= 0;
+        requires 1 <= |Q|;
         ensures #Q = Q o <E>;
 end Remove_Last_Capability;
 


### PR DESCRIPTION
Changed the requires clause to say 1 <= |Q| for the prover